### PR TITLE
246 add better auth endpoints to scalar api docs

### DIFF
--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -23,6 +23,10 @@ app
         disabled: true,
       },
       hideClientButton: true,
+      sources: [
+        { url: "/api/docs/json", title: "API" }, // API endpoints
+        { url: "/api/auth/open-api/generate-schema", title: "Auth" }, // Better Auth schema generation endpoint
+      ],
     },
   })
   .register(fastifyCors, {

--- a/api/src/routes/auth/index.ts
+++ b/api/src/routes/auth/index.ts
@@ -8,7 +8,7 @@ export const authRoutes: FastifyPluginAsync = async (instance) => {
     method: ["GET", "POST"],
     url: "/auth/*",
     schema: {
-      tags: ["auth"],
+      hide: true,
     },
     async handler(request, reply) {
       try {

--- a/api/src/routes/index.ts
+++ b/api/src/routes/index.ts
@@ -35,4 +35,21 @@ export const routes: FastifyPluginAsync = async (instance) => {
       return res.send({ ok: true });
     },
   );
+
+  app.get(
+    "/docs/json", // Make it available for API docs website to fetch JSON file
+    {
+      schema: {
+        hide: true, // Hide from API & Swagger docs (UI & JSON)
+        response: {
+          "200": z.any(),
+        },
+        summary: "Receive Swagger docs in JSON format",
+        tags: ["Documentation"],
+      },
+    },
+    async (_, res) => {
+      return res.send(app.swagger());
+    },
+  );
 };

--- a/api/src/services/auth/client.ts
+++ b/api/src/services/auth/client.ts
@@ -2,7 +2,7 @@ import { betterAuth } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { databaseClient } from "../drizzle-database/client";
 import * as schema from "../drizzle-database/schemas/auth";
-import { username } from "better-auth/plugins";
+import { username, openAPI } from "better-auth/plugins";
 import { config } from "../../config";
 
 export const authClient = betterAuth({
@@ -20,5 +20,10 @@ export const authClient = betterAuth({
     autoSignIn: false,
     requireEmailVerification: false,
   },
-  plugins: [username()],
+  plugins: [
+    username(),
+    openAPI({
+      disableDefaultReference: true,
+    }),
+  ],
 });


### PR DESCRIPTION
- **chore(api): hides auth endpoints from swagger documentation**
- **feat(api): adds route to get swagger docs in JSON format**
- **feat(api): adds openAPI plugin to better auth client**
- **feat(api): adds better auth api docs & api endpoints to scalar docs**
